### PR TITLE
No warning when a top level test has no subtests

### DIFF
--- a/testdata/src/test/without_sub_test.go
+++ b/testdata/src/test/without_sub_test.go
@@ -1,0 +1,10 @@
+package test
+
+import (
+	"testing"
+)
+
+func TestWithoutSub(t *testing.T) { // OK
+	t.Parallel()
+	call("TestWithoutSub")
+}

--- a/tparallel.go
+++ b/tparallel.go
@@ -40,6 +40,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 	testMap := getTestMap(ssaanalyzer, testTyp) // ex. {Test1: [TestSub1, TestSub2], Test2: [TestSub1, TestSub2, TestSub3], ...}
 	for top, subs := range testMap {
+		if len(subs) == 0 {
+			continue
+		}
 		isParallelTop := ssafunc.IsCalled(top, parallel)
 		isPararellSub := false
 		for _, sub := range subs {


### PR DESCRIPTION
If a top-level test has no subtests, tparallel should not warn regardless of whether `t.Parallel()` is called or not.

fixes #8 