### PR TITLE
fix: panic runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/testmap.go
+++ b/testmap.go
@@ -49,6 +49,10 @@ func appendTestMap(subtests []*ssa.Function, instr ssa.Instruction) []*ssa.Funct
 	}
 
 	ssaCall := call.Value()
+	if ssaCall == nil {
+		return subtests
+	}
+
 	for _, arg := range ssaCall.Call.Args {
 		switch arg := arg.(type) {
 		case *ssa.Function:


### PR DESCRIPTION
```
[runner] Panic: tparallel: package \"testing_test\" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference: goroutine 11990 [running]:
runtime/debug.Stack()
	/usr/lib/go/src/runtime/debug/stack.go:24 +0x5e
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func1()
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:109 +0x277
panic({0x18105a0?, 0x255e430?})
	/usr/lib/go/src/runtime/panic.go:770 +0x132
github.com/moricho/tparallel.appendTestMap({0x27ad6e0, 0x0, 0x0}, {0x1c82ae8?, 0xc0230e3d10?})
	/home/ldez/sources/go/pkg/mod/github.com/moricho/tparallel@v0.3.1/testmap.go:52 +0x5d
github.com/moricho/tparallel.getTestMap(0xc0193164c0, {0x1c75b60, 0xc006d97030})
	/home/ldez/sources/go/pkg/mod/github.com/moricho/tparallel@v0.3.1/testmap.go:35 +0x2ca
github.com/moricho/tparallel.run(0xc016e1e620)
	/home/ldez/sources/go/pkg/mod/github.com/moricho/tparallel@v0.3.1/tparallel.go:41 +0x169
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyze(0xc0024d9d80)
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:191 +0xa02
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe.func2()
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:113 +0x17
github.com/golangci/golangci-lint/pkg/timeutils.(*Stopwatch).TrackStage(0xc00259ae10, {0x19b45ef, 0x9}, 0xc0020d7748)
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/timeutils/stopwatch.go:111 +0x44
github.com/golangci/golangci-lint/pkg/goanalysis.(*action).analyzeSafe(0xc00240e420?)
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_action.go:112 +0x7a
github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze.func2(0xc0024d9d80)
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:80 +0xa8
created by github.com/golangci/golangci-lint/pkg/goanalysis.(*loadingPackage).analyze in goroutine 1920
	/home/ldez/sources/go/src/github.com/golangci/golangci-lint/pkg/goanalysis/runner_loadingpackage.go:75 +0x205
```
