### PR TITLE
Fix: Do not require t.Parallel if the function uses t.Setenv

### DIFF
--- a/testdata/src/test/setenv_test.go
+++ b/testdata/src/test/setenv_test.go
@@ -1,0 +1,22 @@
+package test
+
+import (
+	"testing"
+)
+
+func Test_SetEnv_Func1(t *testing.T) {
+	teardown := setup("Test_Setenv_Func1")
+	t.Cleanup(teardown)
+
+	t.Setenv("foo", "bar")
+
+	t.Run("Setenv_Func1_Sub1", func(t *testing.T) {
+		call("Setenv_Func1_Sub1")
+		t.Parallel()
+	})
+
+	t.Run("Setenv_Func1_Sub2", func(t *testing.T) {
+		call("Setenv_Func1_Sub2")
+		t.Parallel()
+	})
+}

--- a/tparallel.go
+++ b/tparallel.go
@@ -37,12 +37,15 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	parallel, _ := p.(*types.Func)
 	c, _, _ := types.LookupFieldOrMethod(testTyp, true, testPkg, "Cleanup")
 	cleanup, _ := c.(*types.Func)
+	s, _, _ := types.LookupFieldOrMethod(testTyp, true, testPkg, "Setenv")
+	setenv, _ := s.(*types.Func)
 
 	testMap := getTestMap(ssaanalyzer, testTyp) // ex. {Test1: [TestSub1, TestSub2], Test2: [TestSub1, TestSub2, TestSub3], ...}
 	for top, subs := range testMap {
 		if len(subs) == 0 {
 			continue
 		}
+		topSetsEnv := ssafunc.IsCalled(top, setenv)
 		isParallelTop := ssafunc.IsCalled(top, parallel)
 		isPararellSub := false
 		for _, sub := range subs {
@@ -61,7 +64,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 		if isParallelTop == isPararellSub {
 			continue
-		} else if isPararellSub {
+		} else if isPararellSub && !topSetsEnv {
 			pass.Reportf(top.Pos(), "%s should call t.Parallel on the top level as well as its subtests", top.Name())
 		} else if isParallelTop {
 			pass.Reportf(top.Pos(), "%s's subtests should call t.Parallel", top.Name())

--- a/tparallel.go
+++ b/tparallel.go
@@ -45,26 +45,26 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		if len(subs) == 0 {
 			continue
 		}
-		topSetsEnv := ssafunc.IsCalled(top, setenv)
+		usesSetenv := ssafunc.IsCalled(top, setenv)
 		isParallelTop := ssafunc.IsCalled(top, parallel)
-		isPararellSub := false
+		isParallelSub := false
 		for _, sub := range subs {
-			isPararellSub = ssafunc.IsCalled(sub, parallel)
-			if isPararellSub {
+			isParallelSub = ssafunc.IsCalled(sub, parallel)
+			if isParallelSub {
 				break
 			}
 		}
 
 		if ssafunc.IsDeferCalled(top) {
 			useCleanup := ssafunc.IsCalled(top, cleanup)
-			if isPararellSub && !useCleanup {
+			if isParallelSub && !useCleanup {
 				pass.Reportf(top.Pos(), "%s should use t.Cleanup instead of defer", top.Name())
 			}
 		}
 
-		if isParallelTop == isPararellSub {
+		if isParallelTop == isParallelSub {
 			continue
-		} else if isPararellSub && !topSetsEnv {
+		} else if isParallelSub && !usesSetenv {
 			pass.Reportf(top.Pos(), "%s should call t.Parallel on the top level as well as its subtests", top.Name())
 		} else if isParallelTop {
 			pass.Reportf(top.Pos(), "%s's subtests should call t.Parallel", top.Name())


### PR DESCRIPTION
This pull request updates the linter so it does not report an error when `t.SetEnv` is used.

For example
```go
func TestSomething(t *testing.T) {
	t.Setenv("foo", "bar")

	t.Run("Test 1", func(t *testing.T) {
		t.Parallel()

		// actual test
	})

	t.Run("test 2", func(t *testing.T) {		                
		// actual test
	})
}
```

TestSomething cannot be run in parallel as it sets an env variable. However, once or more children could still be allowed to run in parallel. When combined to other linters like `paralleltest`, this conflicts and forces developers to add `nolint` comments to their tests.

Fixes #25 